### PR TITLE
#861mdhae1 add addres to location type

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,7 @@
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
 
 PGADMIN_DEFAULT_EMAIL=admin@gapp.com
 PGADMIN_DEFAULT_PASSWORD=admin
 
-DB_CONNECTION_STRING=postgres://postgres:postgres@db:5432/gapp
-DB_CONNECTION_STRING_TEST=postgres://mocha:mocha@db:5432/mocha
+DB_CONNECTION_STRING=postgres://postgres@db:5432/gapp
+DB_CONNECTION_STRING_TEST=postgres://mocha:5432/mocha

--- a/docker-compose.migrate.yml
+++ b/docker-compose.migrate.yml
@@ -12,6 +12,8 @@ services:
       HOLD_ON_FOR_DB_HOST: ${HOLD_ON_FOR_DB_HOST:-db}
       HOLD_ON_FOR_DB_USER: ${HOLD_ON_FOR_DB_USER:-postgres}
       DB_CONNECTION_STRING: postgres://postgres:postgres@db:5432/gapp
+    volumes:
+      - ./src:/gapp/src
     ports:
       - 3000:3000
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,6 +12,8 @@ services:
       HOLD_ON_FOR_DB_HOST: ${HOLD_ON_FOR_DB_HOST:-db}
       HOLD_ON_FOR_DB_USER: ${HOLD_ON_FOR_DB_USER:-mocha}
       DB_CONNECTION_STRING_TEST: postgres://mocha:mocha@db:5432/mocha
+    volumes:
+      - ./src:/gapp/src
     ports:
       - 3000:3000
     command: sh -c "scripts/hold_on_for_db then yarn migrate && yarn test"

--- a/postgres/000-mocha-database.sh
+++ b/postgres/000-mocha-database.sh
@@ -3,7 +3,7 @@
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" <<-EOSQL
-  SELECT 'CREATE USER mocha WITH PASSWORD ''mocha'' SUPERUSER;'
+  SELECT 'CREATE USER mocha SUPERUSER;'
   WHERE NOT EXISTS (SELECT usename FROM "pg_catalog"."pg_user" WHERE usename='mocha') \gexec
 
 

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -3,5 +3,5 @@ FROM postgres:15
 ADD 000-mocha-database.sh /docker-entrypoint-initdb.d/
 
 ENV POSTGRES_USER=${POSTGRES_USER:-postgres}
-ENV POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+ENV POSTGRES_HOST_AUTH_METHOD=trust
 ENV POSTGRES_DB=${POSTGRES_DB:-gapp}

--- a/src/models/location.ts
+++ b/src/models/location.ts
@@ -14,6 +14,7 @@ import {
 import { v4 as uuidv4 } from 'uuid';
 import { Field, InputType, ObjectType } from 'type-graphql';
 import { Person } from './person';
+import { getAddress } from './utils';
 
 export interface LocationAttributes {
   id: string;
@@ -59,6 +60,11 @@ export class Location
   @AllowNull(true)
   @Column
   city?: string;
+
+  @Field()
+  address(): string {
+    return getAddress(this.place, this.city, this.country);
+  }
 
   @Field({ nullable: true })
   @AllowNull(true)

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -1,2 +1,5 @@
 export const getName = (...args: Array<string | undefined>): string =>
   args.filter(Boolean).join(' ');
+
+export const getAddress = (...args: Array<string | undefined>): string =>
+  args.filter(Boolean).join(', ');

--- a/src/test/helpers/utils.test.ts
+++ b/src/test/helpers/utils.test.ts
@@ -1,6 +1,6 @@
 import expect from 'expect';
 
-import { getName } from '../../models/utils';
+import { getName, getAddress } from '../../models/utils';
 
 describe('models utils', () => {
   describe('getName()', () => {
@@ -17,6 +17,23 @@ describe('models utils', () => {
 
     it('should return proper name without the middle name', () => {
       expect(getName(firstName, undefined, lastName)).toBe(nameWithoutMiddle);
+    });
+  });
+
+  describe('getAddress()', () => {
+    const country = 'Atlantis';
+    const city = 'Gotham';
+    const place = 'Valley';
+
+    const locationAll3 = 'Valley, Gotham, Atlantis';
+    const locationCityCountry = 'Gotham, Atlantis';
+
+    it('should return proper address: place, city, country', () => {
+      expect(getAddress(place, city, country)).toBe(locationAll3);
+    });
+
+    it('should return proper address without place: city, country', () => {
+      expect(getAddress(undefined, city, country)).toBe(locationCityCountry);
     });
   });
 });


### PR DESCRIPTION
**Ticket**
[add address to location](https://app.clickup.com/t/861mdhae1)

BTW several bugs surfaced su fixed within this ticket:
1. single quote escape in SQL `here document` in shell script perfectly works on ubuntu, but not on macos, so I got rid of password for `postgres` and `mocha` users.
2. there was the bug lurking in `docker-compose` files for test and migration. it used the source code that was only accessible at image creation time.