### PR TITLE
861myu9tc create people api endpoint

### DIFF
--- a/src/graphql/resolvers/person/helpers.ts
+++ b/src/graphql/resolvers/person/helpers.ts
@@ -1,8 +1,22 @@
 import { Op } from 'sequelize';
 
-import { Child, ParentRelation, Person, PersonCreationAttributes, Spouse } from '../../../models';
-import { logger } from '../../../utils';
-import { PersonInput, PersonBirthInput, PersonMarriageInput } from '../types';
+import {
+  Child,
+  Location,
+  ParentRelation,
+  Person,
+  PersonCreationAttributes,
+  Spouse,
+} from '../../../models';
+import { isEmpty, logger } from '../../../utils';
+import {
+  PersonInput,
+  PersonBirthInput,
+  PersonMarriageInput,
+  PeopleSearchInput,
+  PersonSearch,
+  LocationSearch,
+} from '../types';
 
 const log = logger('Person');
 
@@ -197,4 +211,54 @@ export const updatePersonLocation = async (
     log.error('update', (error as Error).message);
   }
   return false;
+};
+
+type SearchOptions = Record<string, object>;
+
+export const getPersonsSearchOptions = (personSearchObj: Partial<PersonSearch>): SearchOptions =>
+  Object.keys(personSearchObj ?? {}).reduce((searchObj: SearchOptions, key) => {
+    // TODO: how to handle dates, i.e. bod and dod?
+    // TODO: logic for name field, should be used only if firstName and lastName are empty
+    const operation = key.includes('Id') ? Op.eq : Op.iLike;
+    searchObj[key] = {
+      [operation]:
+        operation === Op.iLike
+          ? `%${personSearchObj[key as keyof PersonSearch]}%`
+          : personSearchObj[key as keyof PersonSearch],
+    };
+    return searchObj;
+  }, {});
+
+export const getLocations = async (
+  locationSearchObj: Partial<LocationSearch>,
+): Promise<Location[]> => {
+  const searchObj = Object.keys(locationSearchObj ?? {}).reduce((searchObj: SearchOptions, key) => {
+    // TODO: logic for address field, should be used only if other are empty
+    searchObj[key] = { [Op.iLike]: locationSearchObj[key as keyof LocationSearch] };
+    return searchObj;
+  }, {});
+
+  return isEmpty(searchObj) ? [] : await Location.findAll({ where: searchObj });
+};
+
+export const getPeople = async (searchOptions: PeopleSearchInput): Promise<Person[]> => {
+  const personsSearchOptions = getPersonsSearchOptions(searchOptions.person);
+
+  const places = !searchOptions?.person?.placeId && (await getLocations(searchOptions.place));
+  if (places && places?.length) {
+    personsSearchOptions.placeId = {
+      [Op.in]: (places as unknown as Location[]).map(({ id }) => id),
+    };
+  }
+
+  const placesOfBirth =
+    !searchOptions?.person?.pobId && (await getLocations(searchOptions.placeOfBirth));
+  if (placesOfBirth && placesOfBirth?.length) {
+    personsSearchOptions.pobId = {
+      [Op.in]: (placesOfBirth as unknown as Location[]).map(({ id }) => id),
+    };
+  }
+
+  console.log('DEBUG:personsSearchOptions', personsSearchOptions);
+  return isEmpty(personsSearchOptions) ? [] : await Person.findAll({ where: personsSearchOptions });
 };

--- a/src/graphql/resolvers/person/person.ts
+++ b/src/graphql/resolvers/person/person.ts
@@ -2,14 +2,21 @@ import { Arg, Ctx, FieldResolver, Mutation, Query, Resolver, Root } from 'type-g
 
 import { Location, Person } from '../../../models';
 import { Context } from '../../context';
-import { PersonInput } from '../types';
-import { addPerson, getChildren, getParents, getSpouses, updatePerson } from './helpers';
+import { PeopleSearchInput, PersonInput } from '../types';
+import { addPerson, getChildren, getParents, getPeople, getSpouses, updatePerson } from './helpers';
 
 @Resolver(() => Person)
 export class PersonResolvers {
   @Query(() => [Person])
   async persons(): Promise<Person[]> {
     return await Person.findAll();
+  }
+
+  @Query(() => [Person])
+  async people(
+    @Arg('searchOptions', () => PeopleSearchInput) searchOptions: PeopleSearchInput,
+  ): Promise<Person[]> {
+    return await getPeople(searchOptions);
   }
 
   @FieldResolver()

--- a/src/graphql/resolvers/types.ts
+++ b/src/graphql/resolvers/types.ts
@@ -117,13 +117,13 @@ export class LocationSearch extends LocationInput {
 @InputType()
 export class PeopleSearchInput {
   @Field(() => PersonSearch, { nullable: true })
-  person: Partial<PersonSearch>;
+  person?: Partial<PersonSearch>;
   @Field(() => PersonSearch, { nullable: true })
-  parents: Partial<PersonSearch>;
+  parents?: Partial<PersonSearch>;
   @Field(() => PersonSearch, { nullable: true })
-  children: Partial<PersonSearch>;
+  children?: Partial<PersonSearch>;
   @Field(() => LocationSearch, { nullable: true })
-  place: Partial<LocationSearch>;
+  place?: Partial<LocationSearch>;
   @Field(() => LocationSearch, { nullable: true })
-  placeOfBirth: Partial<LocationSearch>;
+  placeOfBirth?: Partial<LocationSearch>;
 }

--- a/src/graphql/resolvers/types.ts
+++ b/src/graphql/resolvers/types.ts
@@ -103,3 +103,27 @@ export class ChildRelationsInput {
   @Field({ nullable: true })
   parent2relation?: ParentRelation;
 }
+
+@InputType()
+export class PersonSearch extends PersonInput {
+  name?: string;
+}
+
+@InputType()
+export class LocationSearch extends LocationInput {
+  address?: string;
+}
+
+@InputType()
+export class PeopleSearchInput {
+  @Field(() => PersonSearch, { nullable: true })
+  person: Partial<PersonSearch>;
+  @Field(() => PersonSearch, { nullable: true })
+  parents: Partial<PersonSearch>;
+  @Field(() => PersonSearch, { nullable: true })
+  children: Partial<PersonSearch>;
+  @Field(() => LocationSearch, { nullable: true })
+  place: Partial<LocationSearch>;
+  @Field(() => LocationSearch, { nullable: true })
+  placeOfBirth: Partial<LocationSearch>;
+}

--- a/src/graphql/resolvers/types.ts
+++ b/src/graphql/resolvers/types.ts
@@ -122,6 +122,8 @@ export class PeopleSearchInput {
   parents?: Partial<PersonSearch>;
   @Field(() => PersonSearch, { nullable: true })
   children?: Partial<PersonSearch>;
+  @Field(() => PersonSearch, { nullable: true })
+  spouses?: Partial<PersonSearch>;
   @Field(() => LocationSearch, { nullable: true })
   place?: Partial<LocationSearch>;
   @Field(() => LocationSearch, { nullable: true })

--- a/src/test/utils/utils.ts
+++ b/src/test/utils/utils.ts
@@ -1,5 +1,6 @@
 import DataLoader from 'dataloader';
 import { QueryTypes } from 'sequelize';
+import { v4 as uuidv4 } from 'uuid';
 
 import { getTestSequelize } from './testSequelize';
 import { Context } from '../../graphql';
@@ -13,8 +14,9 @@ import {
   PersonCreationAttributes,
   Spouse,
 } from '../../models';
+import { range } from '../../utils';
 
-export const randomString = () => '' + Math.random();
+export const randomString = () => ('' + Math.random()).substring(2);
 
 export const getPersonAttributes = (
   personAttributes: PersonCreationAttributes,
@@ -51,6 +53,28 @@ export const createLocationForTest = (
     country,
     ...(place ? { place: name } : { city: name }),
   });
+
+interface CreatePeopleAtLocationForTest {
+  number?: number;
+  doSave?: boolean;
+  placeId?: string;
+  pobId?: string;
+}
+export const createPeopleAtLocationForTest = async (
+  { number, doSave, placeId, pobId }: CreatePeopleAtLocationForTest = {
+    number: 2,
+    doSave: false,
+    placeId: uuidv4(),
+    pobId: uuidv4(),
+  },
+) =>
+  await Promise.all(
+    range(number as number).map(async () => {
+      const person = createPersonForTest(placeId, pobId);
+      if (doSave) await person.save();
+      return person;
+    }),
+  );
 
 export const createFamilyForTest = () => {
   const home = createLocationForTest();

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,6 @@
 export * from './logger';
-export * from './isEmpty';
+
+export const isEmpty = (obj: object) => Object.keys(obj).length === 0;
+
+export const range = (length: number, from = 0) =>
+  new Array(length).fill(undefined).map((_, idx) => idx + from);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './logger';
+export * from './isEmpty';

--- a/src/utils/isEmpty.ts
+++ b/src/utils/isEmpty.ts
@@ -1,0 +1,1 @@
+export const isEmpty = (obj: object) => Object.keys(obj).length === 0;


### PR DESCRIPTION
## Description
<!-- Please provide a brief description of the changes in this pull request. -->
The first step adding endpoint `people` for searching people.
It comprises creation of resolver and adding 3 out of 5 search options:
1. by attributes of person
2. by attributes of location applied to a place of living
3.  and to place of birth

## Ticket
<!-- Please provide a link to a ticket -->
[add people endpoint](https://app.clickup.com/t/861myu9tc)

## Changes
<!-- Please list major changes. Would be good if that matches commits -->
1. new utility `isEmpty`
2. new endpoint at person model resolvers
3. updated search object structure and moved `isEmpty`
4. created test util and added tests

## Screenshots
<!-- Please provide screenshots if applicable -->

## Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation (if applicable)
