### PR TITLE
861myubfa fix creating a location with the same attributes

### DIFF
--- a/src/graphql/resolvers/location/index.ts
+++ b/src/graphql/resolvers/location/index.ts
@@ -3,13 +3,29 @@ import { Query, Mutation, Resolver, Arg, FieldResolver, Root, Ctx } from 'type-g
 import { Country, Location, Person } from '../../../models';
 import { Context } from '../../context';
 import { LocationInput } from '../types';
-import { addLocation, getAllCountries, updateLocation } from './helpers';
+import {
+  addLocation,
+  doesLocationExist,
+  getAllCountries,
+  getLocations,
+  updateLocation,
+} from './helpers';
 
 @Resolver(() => Location)
 export class LocationResolvers {
   @Query(() => [Location])
-  async locations(): Promise<Location[]> {
+  async allLocations(): Promise<Location[]> {
     return await Location.findAll();
+  }
+
+  @Query(() => [Location])
+  async locations(
+    @Arg('locationAttributes', () => LocationInput)
+    locationAttributes: LocationInput,
+  ): Promise<Location[]> {
+    const result = await getLocations(locationAttributes);
+    console.log('DEBUG:LocationResolvers:locations:result:', result);
+    return result;
   }
 
   @FieldResolver()
@@ -34,6 +50,8 @@ export class LocationResolvers {
     @Arg('locationAttributes', () => LocationInput)
     locationAttributes: LocationInput,
   ): Promise<Location | null> {
+    if (await doesLocationExist(locationAttributes)) throw new Error('Location already exists');
+
     return addLocation(locationAttributes);
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './logger';
+export * from './inputToSearchOptions';
 
 export const isEmpty = (obj: object) => Object.keys(obj).length === 0;
 

--- a/src/utils/inputToSearchOptions.ts
+++ b/src/utils/inputToSearchOptions.ts
@@ -1,0 +1,15 @@
+import { Op } from 'sequelize';
+
+type SearchOptions = Record<string, unknown>;
+export interface InputToSearchOptions {
+  equalKeys?: string[];
+  dateKeys?: string[];
+}
+export const inputToSearchOptions = (inputObj: SearchOptions, options?: InputToSearchOptions) =>
+  Object.keys(inputObj ?? {}).reduce((searchObj: SearchOptions, key) => {
+    if (options?.equalKeys && key in options.equalKeys) searchObj[key] = inputObj[key];
+    else if (options?.dateKeys && options.dateKeys)
+      searchObj[key] = inputObj[key]; // TODO: logic for date fields
+    else searchObj[key] = { [Op.iLike]: inputObj[key] };
+    return searchObj;
+  }, {});


### PR DESCRIPTION
## Description
<!-- Please provide a brief description of the changes in this pull request. -->
Fixed the bug of creating a location with already existing attributes

## Ticket
<!-- Please provide a link to a ticket -->
[prevent from creating a location with the same attributes(https://app.clickup.com/t/861myubfa)

## Changes
<!-- Please list major changes. Would be good if that matches commits -->
1. added the util for converting `InputType` args to sort of `WhereOptions` type object
2. then renamed already existing `locations` endpoint to `allLocations` and added endpoint `locations` which takes an object and returns matching locations
3. updated tests

## Screenshots
<!-- Please provide screenshots if applicable -->


## Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation (if applicable)
