### PR TITLE
863gqr7uw fix place id or pob id null

### DIFF
--- a/src/graphql/resolvers/person/person.ts
+++ b/src/graphql/resolvers/person/person.ts
@@ -40,13 +40,13 @@ export class PersonResolvers {
   @FieldResolver()
   @Query(() => Location)
   async place(@Root() parent: Person, @Ctx() ctx: Context) {
-    return await ctx.placeLoader.load(parent.placeId);
+    return parent.placeId ? await ctx.placeLoader.load(parent.placeId) : null;
   }
 
   @FieldResolver()
   @Query(() => Location)
   async placeOfBirth(@Root() parent: Person, @Ctx() ctx: Context) {
-    return await ctx.placeLoader.load(parent.pobId);
+    return parent.pobId ? await ctx.placeLoader.load(parent.pobId) : null;
   }
 
   @Mutation(() => Person)

--- a/src/test/resolvers/person/person.test.ts
+++ b/src/test/resolvers/person/person.test.ts
@@ -104,24 +104,41 @@ describe('PersonResolvers', () => {
 
   describe('field resolvers', () => {
     describe('locations', () => {
-      let place: Location;
-      let placeOfBirth: Location;
+      let place: Location | null;
+      let placeOfBirth: Location | null;
       const ctx = getContextForTest();
       const location = createLocationForTest();
       const person = createPersonForTest(location.id, location.id);
 
-      before(async () => {
-        ctx.placeLoader.load = () => Promise.resolve(location);
-        place = await resolver.place(person, ctx);
-        placeOfBirth = await resolver.placeOfBirth(person, ctx);
-      });
+      describe('person has got set location ids', () => {
+        before(async () => {
+          ctx.placeLoader.load = () => Promise.resolve(location);
+          place = await resolver.place(person, ctx);
+          placeOfBirth = await resolver.placeOfBirth(person, ctx);
+        });
 
-      it('place should return a location', () => {
-        expect(place).toEqual(location);
-      });
+        it('place should return a location', () => {
+          expect(place).toEqual(location);
+        });
 
-      it('placeOfBirth should return a location', () => {
-        expect(placeOfBirth).toEqual(location);
+        it('placeOfBirth should return a location', () => {
+          expect(placeOfBirth).toEqual(location);
+        });
+      });
+      describe('person has got set location ids to null', () => {
+        before(async () => {
+          ctx.placeLoader.load = () => Promise.resolve(null as unknown as Location);
+          place = await resolver.place(person, ctx);
+          placeOfBirth = await resolver.placeOfBirth(person, ctx);
+        });
+
+        it('place should return null', () => {
+          expect(place).toBe(null);
+        });
+
+        it('placeOfBirth should return null', () => {
+          expect(placeOfBirth).toBe(null);
+        });
       });
     });
 


### PR DESCRIPTION
## Description
<!-- Please provide a brief description of the changes in this pull request. -->
Fix error when person has got `placeId` or/and `pobId` null

## Ticket
<!-- Please provide a link to a ticket -->
[empty locations error](https://app.clickup.com/t/863gqr7uw)

## Changes
<!-- Please list major changes. Would be good if that matches commits -->
1. fixed the bug
2. added test for null values

## Screenshots
<!-- Please provide screenshots if applicable -->


## Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation (if applicable)
