### PR TITLE
861n1ma4y add date fields conversion

### DIFF
--- a/src/graphql/resolvers/location/index.ts
+++ b/src/graphql/resolvers/location/index.ts
@@ -24,7 +24,6 @@ export class LocationResolvers {
     locationAttributes: LocationInput,
   ): Promise<Location[]> {
     const result = await getLocations(locationAttributes);
-    console.log('DEBUG:LocationResolvers:locations:result:', result);
     return result;
   }
 

--- a/src/graphql/resolvers/person/helpers.ts
+++ b/src/graphql/resolvers/person/helpers.ts
@@ -9,7 +9,13 @@ import {
   Spouse,
 } from '../../../models';
 import { SearchOptions, inputToSearchOptions, isEmpty, logger } from '../../../utils';
-import { PersonInput, PersonBirthInput, PersonMarriageInput, PeopleSearchInput } from '../types';
+import {
+  dateFields,
+  PersonInput,
+  PersonBirthInput,
+  PersonMarriageInput,
+  PeopleSearchInput,
+} from '../types';
 
 const log = logger('Person');
 
@@ -218,6 +224,7 @@ export const getPeople = async (searchOptions: PeopleSearchInput): Promise<Perso
   ).filter((key) => key.includes('Id'));
   const personsSearchOptions = inputToSearchOptions(searchOptions?.person as SearchOptions, {
     equalKeys,
+    dateKeys: dateFields,
   });
 
   const places =

--- a/src/graphql/resolvers/types.ts
+++ b/src/graphql/resolvers/types.ts
@@ -129,3 +129,5 @@ export class PeopleSearchInput {
   @Field(() => LocationSearch, { nullable: true })
   placeOfBirth?: Partial<LocationSearch>;
 }
+
+export const dateFields = ['dob', 'dod', 'wedding', 'divorce'];

--- a/src/utils/inputToSearchOptions.ts
+++ b/src/utils/inputToSearchOptions.ts
@@ -1,4 +1,5 @@
 import { Op } from 'sequelize';
+import { logger } from './logger';
 
 export type SearchOptions = Record<string, unknown>;
 export interface InputToSearchOptions {
@@ -9,7 +10,36 @@ export const inputToSearchOptions = (inputObj: SearchOptions, options?: InputToS
   Object.keys(inputObj ?? {}).reduce((searchObj: SearchOptions, key) => {
     if (options?.equalKeys && options.equalKeys.includes(key)) searchObj[key] = inputObj[key];
     else if (options?.dateKeys && options.dateKeys.includes(key))
-      searchObj[key] = inputObj[key]; // TODO: logic for date fields
+      searchObj[key] = getDateRangeSearchObj(inputObj[key] as string);
     else searchObj[key] = { [Op.iLike]: inputObj[key] };
     return searchObj;
   }, {});
+
+export const getDateRangeSearchObj = (date: string) => {
+  const getLastDay = (date: string): Date => {
+    const [year, month, day] = date.split('-');
+    return day ? new Date(date) : new Date(+year, month ? +month : 12, 0);
+  };
+
+  const [from, to] = date.split(':');
+  const dateFrom = new Date(from);
+  const dateTo = new Date(to);
+
+  if (
+    dateFrom.toString() === 'Invalid Date' ||
+    (to !== undefined && dateTo.toString() === 'Invalid Date')
+  ) {
+    logger('utils').error(
+      'getDateRangeSearchObj()',
+      'got wrong date, correct usage is from:to like "2000:2020-02-02"',
+    );
+    return {};
+  }
+
+  const [, , dayFrom] = from.split('-');
+  if (!!dayFrom && !to) return new Date(dateFrom);
+
+  const dateSearchTo = !!to ? getLastDay(to) : getLastDay(from);
+
+  return { [Op.between]: [dateFrom, dateSearchTo] };
+};


### PR DESCRIPTION
## Description
<!-- Please provide a brief description of the changes in this pull request. -->
update utility of converting args to search options to process date fields. they come as strings and in a search object they need to be of Date type

regarding picking date fields. names of these fields don't follow any particular pattern (like ids have got endings like `...Id`). so I created the array of names and placed in `src/graphql/resolvers/types.ts`. more robust solution might be needed in the future.

## Ticket
<!-- Please provide a link to a ticket -->
[add date fields conversion to `inputToSearchOptions` fn](https://app.clickup.com/t/861n1ma4y)

## Changes
<!-- Please list major changes. Would be good if that matches commits -->
1. fixed forgotten console.log for debugging needs
2. added Date type fields names array
3. added processing of date fields

## Screenshots
<!-- Please provide screenshots if applicable -->


## Checklist

- [x] I have tested the changes locally
- [ ] I have updated the documentation (if applicable)
